### PR TITLE
Bump dune-update action to v0.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
 
       - name: Update Queries
-        uses: bh2smith/dune-update@v0.1.0
+        uses: bh2smith/dune-update@v0.2.0
         with:
           changedQueries: ${{ steps.get-changed-files.outputs.changed_files }}
           duneApiKey: ${{ secrets.DUNE_API_KEY }}


### PR DESCRIPTION
## Summary
- Update `bh2smith/dune-update` from v0.1.0 to v0.2.0
- v0.2.0 includes TypeScript rewrite, node24 runtime, and updated dependencies

## Test plan
- [ ] Merge and push a query change to verify the action runs successfully