### PR TITLE
Bump dune-update action to v0.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "changed_files=$CHANGED_FILES" >> $GITHUB_OUTPUT
 
       - name: Update Queries
-        uses: bh2smith/dune-update@v0.2.0
+        uses: bh2smith/dune-update@v0.2.1
         with:
           changedQueries: ${{ steps.get-changed-files.outputs.changed_files }}
           duneApiKey: ${{ secrets.DUNE_API_KEY }}


### PR DESCRIPTION
## Summary
- Update `bh2smith/dune-update` from v0.2.0 to v0.2.1
- Fixes `MODULE_TYPELESS_PACKAGE_JSON` runtime warning by adding `"type": "module"` to the action's package.json

## Test plan
- [ ] Merge and push a query change to verify warning is gone