### PR TITLE
Fix typo in token_prices query

### DIFF
--- a/queries/token_prices_1791490.sql
+++ b/queries/token_prices_1791490.sql
@@ -6,6 +6,6 @@ FROM
 WHERE
   blockchain = '{{Network}}'
   AND date_trunc('year', minute) = CAST('{{YEAR}}-01-01' AS timestamp)
-  AN contract_address = from_hex('{{TokenAddress}}')
+  AND contract_address = from_hex('{{TokenAddress}}')
 GROUP BY
   date_trunc('day', minute)


### PR DESCRIPTION
## Summary
- Fix `AN` -> `AND` typo in token_prices_1791490.sql

## Test plan
- [ ] dune-update v0.2.1 action triggers on merge without MODULE_TYPELESS_PACKAGE_JSON warning
- [ ] Query updates successfully on Dune